### PR TITLE
Set fixed uid and gid for mule user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,10 @@ gem 'berkshelf'
 #   gem "vagrant-omnibus", github: "schisamo/vagrant-omnibus"
 # end
 
-gem 'test-kitchen'
-gem 'kitchen-vagrant'
+group :test do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'kitchen-ec2'
+  gem 'foodcritic'
+  gem 'kitchen-docker'
+end

--- a/README.md
+++ b/README.md
@@ -44,10 +44,22 @@ Red Hat 6 is also assumed to work.
     <td><tt>mule</tt></td>
   </tr>
   <tr>
+    <td><tt>['mule']['uid']</tt></td>
+    <td>Integer</td>
+    <td>UID for the `mule` user</td>
+    <td><tt>4000</tt></td>
+  </tr>
+  <tr>
     <td><tt>['mule']['group']</tt></td>
     <td>String</td>
     <td>Group that the application user will be a member of.</td>
     <td><tt>mule</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['mule']['gid']</tt></td>
+    <td>Integer</td>
+    <td>GID for the `mule` group</td>
+    <td><tt>4000</tt></td>
   </tr>
   <tr>
     <td><tt>['mule']['package']['base_url']</tt></td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,9 @@ default['mule']['java']['flavor'] = 'oracle'
 default['mule']['java']['version'] = 7
 
 default['mule']['user'] = 'mule'
+default['mule']['uid'] = 4000
 default['mule']['group'] = 'mule'
+default['mule']['gid'] = 4000
 
 default['mule']['package']['base_url'] = 'https://repository.mulesoft.org/nexus/content/repositories/releases/org/mule/distributions/mule-standalone'
 default['mule']['package']['filename'] = 'mule-standalone-' + node['mule']['version'] + '.zip'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,11 +9,17 @@
 
 include_recipe 'mule::_java'
 
+group node['mule']['group'] do
+  gid node['mule']['gid']
+end
+
 user node['mule']['user'] do
   supports manage_home: true
   shell '/bin/bash'
   home "/home/#{node['mule']['user']}"
   comment 'Mule user'
+  uid node['mule']['uid']
+  gid node['mule']['gid']
 end
 
 archive 'mule' do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -9,12 +9,27 @@ describe 'mule::default' do
       expect(mule_user).to exist
     end
 
+    it 'has the correct uid' do
+      expect(mule_user).to have_uid 4000
+    end
+
     it 'has login shell /bin/bash' do
       expect(mule_user).to have_login_shell '/bin/bash'
     end
 
     it 'has a home directory' do
       expect(mule_user).to have_home_directory '/home/mule'
+    end
+  end
+
+  context 'mule group' do
+    let(:mule_group) { group('mule') }
+    it 'is created' do
+      expect(mule_group).to exist
+    end
+
+    it 'has the correct gid' do
+      expect(mule_group).to have_gid 4000
     end
   end
 


### PR DESCRIPTION
This change fixes the `uid` and `gid` for the `mule` user. The default value is `4000`.