### PR TITLE
Use lazy eval of attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,5 +9,6 @@ default['mule']['group'] = 'mule'
 default['mule']['gid'] = 4000
 
 default['mule']['package']['base_url'] = 'https://repository.mulesoft.org/nexus/content/repositories/releases/org/mule/distributions/mule-standalone'
-default['mule']['package']['filename'] = 'mule-standalone-' + node['mule']['version'] + '.zip'
+
+default['mule']['package']['filename'] = "mule-standalone-%{version}.zip"
 default['mule']['package']['dir_prefix'] = '/usr/local'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'devops@shopkeep.com'
 license          'All rights reserved'
 description      'Installs/Configures mule'
 long_description 'Installs/Configures mule'
-version          '0.1.1'
+version          '0.1.2'
 
 depends 'apt', '~> 2.6.0'
 depends 'archive', '~> 0.2.6'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ user node['mule']['user'] do
 end
 
 archive 'mule' do
-  url [node['mule']['package']['base_url'], node['mule']['version'], node['mule']['package']['filename']].join('/')
+  url [node['mule']['package']['base_url'], node['mule']['version'], node['mule']['package']['filename'] % {version: node['mule']['verison']}].join('/')
   version node['mule']['version']
   prefix node['mule']['package']['dir_prefix']
   owner node['mule']['user']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ user node['mule']['user'] do
 end
 
 archive 'mule' do
-  url [node['mule']['package']['base_url'], node['mule']['version'], node['mule']['package']['filename'] % {version: node['mule']['verison']}].join('/')
+  url [node['mule']['package']['base_url'], node['mule']['version'], node['mule']['package']['filename'] % {version: node['mule']['version']}].join('/')
   version node['mule']['version']
   prefix node['mule']['package']['dir_prefix']
   owner node['mule']['user']


### PR DESCRIPTION
This is helpful for attributes that are derived from other attributes. Otherwise a wrapper cookbook or any cookbook that references this one and attempts to set the version will have unexpected results. 